### PR TITLE
feat: add ParseLevel function for dynamic log level parsing

### DIFF
--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -26,7 +26,8 @@ func main() {
 	logger.EnableJSONFormat()
 	logger.EnableCallerInfo()
 	logger.EnableTrace()
-	logger.SetLevel(logger.DebugLevel)
+	// logger.SetLevel(logger.DebugLevel)
+	logger.SetLevel(logger.ParseLevel("DEBUG"))
 
 	// This will now output in JSON format
 	logger.Info("Switched default logger to JSON format")

--- a/logger.go
+++ b/logger.go
@@ -45,6 +45,25 @@ func (l Level) String() string {
 	}
 }
 
+// make dynamic level, so if someone can set level from anywhere
+// see example, https://github.com/fanchann/dy/blob/main/example/basic/main.go#L30
+func ParseLevel(l string) Level {
+	switch strings.ToUpper(l) {
+	case "DEBUG":
+		return DebugLevel
+	case "INFO":
+		return InfoLevel
+	case "WARN":
+		return WarnLevel
+	case "ERROR":
+		return ErrorLevel
+	case "FATAL":
+		return FatalLevel
+	default:
+		return InfoLevel // info level for default
+	}
+}
+
 // LogEntry represents a structured log entry for JSON output
 type LogEntry struct {
 	Timestamp   string                 `json:"timestamp,omitempty"`


### PR DESCRIPTION
make log level dynamic by allowing users to set the level from anywhere. this function parses a string into the corresponding log Level, ensuring case-insensitivity and defaulting to INFO if the input is invalid.

See example: 
https://github.com/fanchann/dy/blob/deveploments/example/basic/main.go#L30